### PR TITLE
Add Midtrans payment gateway

### DIFF
--- a/extensions/Gateways/Midtrans/Midtrans.php
+++ b/extensions/Gateways/Midtrans/Midtrans.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Paymenter\Extensions\Gateways\Midtrans;
+
+use App\Classes\Extension\Gateway;
+use App\Helpers\ExtensionHelper;
+use App\Models\Invoice;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\View;
+
+class Midtrans extends Gateway
+{
+    public function boot()
+    {
+        require __DIR__ . '/routes.php';
+        View::addNamespace('gateways.midtrans', __DIR__ . '/resources/views');
+    }
+
+    public function getConfig($values = [])
+    {
+        return [
+            [
+                'name' => 'server_key',
+                'label' => 'Server Key',
+                'type' => 'text',
+                'required' => true,
+            ],
+            [
+                'name' => 'client_key',
+                'label' => 'Client Key',
+                'type' => 'text',
+                'required' => true,
+            ],
+            [
+                'name' => 'test_mode',
+                'label' => 'Test Mode',
+                'type' => 'checkbox',
+                'required' => false,
+            ],
+        ];
+    }
+
+    protected function baseUrl()
+    {
+        return $this->config('test_mode') ? 'https://app.sandbox.midtrans.com' : 'https://app.midtrans.com';
+    }
+
+    protected function request($method, $path, $data = [])
+    {
+        return Http::withBasicAuth($this->config('server_key'), '')
+            ->$method($this->baseUrl() . $path, $data)
+            ->object();
+    }
+
+    public function pay(Invoice $invoice, $total)
+    {
+        $payload = [
+            'transaction_details' => [
+                'order_id' => $invoice->id,
+                'gross_amount' => $total,
+            ],
+            'customer_details' => [
+                'first_name' => $invoice->user->name,
+                'email' => $invoice->user->email,
+            ],
+        ];
+
+        $response = $this->request('post', '/snap/v1/transactions', $payload);
+
+        return view('gateways.midtrans::pay', [
+            'invoice' => $invoice,
+            'token' => $response->token ?? null,
+            'clientKey' => $this->config('client_key'),
+            'snapUrl' => $this->baseUrl() . '/snap/snap.js',
+        ]);
+    }
+
+    public function webhook(Request $request)
+    {
+        $payload = $request->json()->all();
+        $signature = hash('sha512', $payload['order_id'] . $payload['status_code'] . $payload['gross_amount'] . $this->config('server_key'));
+
+        if (!hash_equals($signature, $payload['signature_key'] ?? '')) {
+            return response()->json(['status' => 'invalid'], 400);
+        }
+
+        if (in_array($payload['transaction_status'], ['capture', 'settlement'])) {
+            ExtensionHelper::addPayment(
+                $payload['order_id'],
+                'Midtrans',
+                $payload['gross_amount'],
+                0,
+                $payload['transaction_id'] ?? null
+            );
+        }
+
+        return response()->json(['status' => 'success']);
+    }
+}

--- a/extensions/Gateways/Midtrans/resources/views/pay.blade.php
+++ b/extensions/Gateways/Midtrans/resources/views/pay.blade.php
@@ -1,0 +1,19 @@
+<script src="{{ $snapUrl }}" data-client-key="{{ $clientKey }}"></script>
+@script
+    <script>
+        snap.pay("{{ $token }}", {
+            onSuccess: function () {
+                window.location.href = "{{ route('invoices.show', $invoice) }}?checkPayment=true";
+            },
+            onPending: function () {
+                window.location.href = "{{ route('invoices.show', $invoice) }}?checkPayment=true";
+            },
+            onError: function () {
+                window.location.href = "{{ route('invoices.show', $invoice) }}";
+            },
+            onClose: function () {
+                window.location.href = "{{ route('invoices.show', $invoice) }}";
+            }
+        });
+    </script>
+@endscript

--- a/extensions/Gateways/Midtrans/routes.php
+++ b/extensions/Gateways/Midtrans/routes.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Support\Facades\Route;
+use Paymenter\Extensions\Gateways\Midtrans\Midtrans;
+
+Route::post('/extensions/midtrans/webhook', [Midtrans::class, 'webhook'])->withoutMiddleware([VerifyCsrfToken::class])->name('extensions.gateways.midtrans.webhook');


### PR DESCRIPTION
## Summary
- add Midtrans gateway extension with Snap integration and webhook handling

## Testing
- `composer install --ignore-platform-req=ext-sodium`
- `./vendor/bin/pint`
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689de0a8d3f0832ea32fa93da0d03b42