### PR TITLE
feat: add configurable Duitku gateway

### DIFF
--- a/extensions/Gateways/Duitku/Duitku.php
+++ b/extensions/Gateways/Duitku/Duitku.php
@@ -59,6 +59,14 @@ class Duitku extends Gateway
     }
 
     /**
+     * Determine if the gateway can be used for the given items.
+     */
+    public function canUseGateway($items, $type)
+    {
+        return !empty($this->config('merchant_code')) && !empty($this->config('api_key'));
+    }
+
+    /**
      * Process a payment and return redirect URL or error message.
      */
     public function pay(Invoice $invoice, $total)

--- a/extensions/Gateways/Duitku/Duitku.php
+++ b/extensions/Gateways/Duitku/Duitku.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Paymenter\Extensions\Gateways\Duitku;
+
+use App\Classes\Extension\Gateway;
+use App\Models\Invoice;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class Duitku extends Gateway
+{
+    /**
+     * Get configuration fields for the gateway.
+     */
+    public function getConfig($values = [])
+    {
+        return [
+            [
+                'name' => 'merchant_code',
+                'label' => 'Merchant Code',
+                'type' => 'text',
+                'required' => true,
+            ],
+            [
+                'name' => 'api_key',
+                'label' => 'API Key',
+                'type' => 'text',
+                'required' => true,
+            ],
+            [
+                'name' => 'payment_method',
+                'label' => 'Payment Method',
+                'type' => 'select',
+                'options' => [
+                    'OV' => 'OVO',
+                    'SA' => 'ShopeePay',
+                    'DA' => 'DANA',
+                    'LJ' => 'LinkAja',
+                    'QRIS' => 'QRIS',
+                    'BT' => 'Permata Virtual Account',
+                    'BC' => 'BCA Virtual Account',
+                    'BR' => 'BRI Virtual Account',
+                    'NI' => 'BNI Virtual Account',
+                    'AK' => 'Akulaku Paylater',
+                ],
+                'description' => 'Choose the payment method to use',
+                'required' => true,
+            ],
+            [
+                'name' => 'sandbox_mode',
+                'label' => 'Sandbox Mode',
+                'type' => 'checkbox',
+                'description' => 'Enable sandbox mode for testing',
+                'required' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Process a payment and return redirect URL or error message.
+     */
+    public function pay(Invoice $invoice, $total)
+    {
+        $merchantCode = $this->config('merchant_code');
+        $apiKey = $this->config('api_key');
+        $paymentMethod = $this->config('payment_method');
+        $baseUrl = $this->config('sandbox_mode') ? 'https://api-sandbox.duitku.com' : 'https://api.duitku.com';
+
+        $payload = [
+            'merchantCode' => $merchantCode,
+            'paymentAmount' => $total,
+            'paymentMethod' => $paymentMethod,
+            'merchantOrderId' => (string) $invoice->id,
+            'productDetails' => 'Invoice #' . $invoice->id,
+            'customerVaName' => $invoice->user->name ?? 'Customer',
+            'email' => $invoice->user->email ?? 'customer@example.com',
+            'signature' => md5($merchantCode . $invoice->id . $total . $apiKey),
+        ];
+
+        try {
+            $response = Http::post($baseUrl . '/api/merchant/v2/inquiry', $payload);
+        } catch (ConnectionException|Throwable $e) {
+            Log::error('Duitku API request failed', ['message' => $e->getMessage()]);
+
+            return 'Payment could not be processed. Please try again later.';
+        }
+
+        if (!$response->successful()) {
+            Log::error('Duitku API responded with error', [
+                'status' => $response->status(),
+                'body' => $response->body(),
+            ]);
+
+            return 'Payment could not be processed. Please try again later.';
+        }
+
+        $data = $response->json();
+
+        return $data['paymentUrl'] ?? '';
+    }
+}

--- a/tests/Unit/DuitkuGatewayTest.php
+++ b/tests/Unit/DuitkuGatewayTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Invoice;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Paymenter\Extensions\Gateways\Duitku\Duitku;
+use Tests\TestCase;
+
+class DuitkuGatewayTest extends TestCase
+{
+    public function test_pay_success()
+    {
+        Http::fake([
+            '*' => Http::response(['paymentUrl' => 'https://duitku.test/redirect'], 200),
+        ]);
+
+        $invoice = new Invoice;
+        $invoice->id = 1;
+        $invoice->currency_code = 'IDR';
+        $invoice->user = (object) ['name' => 'John Doe', 'email' => 'john@example.com'];
+
+        $gateway = new Duitku([
+            'merchant_code' => 'M123',
+            'api_key' => 'secret',
+            'payment_method' => 'QRIS',
+            'sandbox_mode' => true,
+        ]);
+
+        $url = $gateway->pay($invoice, 10);
+
+        $this->assertSame('https://duitku.test/redirect', $url);
+    }
+
+    public function test_pay_failure_logs_and_returns_message()
+    {
+        Http::fake([
+            '*' => Http::response('Error', 500),
+        ]);
+
+        Log::spy();
+
+        $invoice = new Invoice;
+        $invoice->id = 1;
+        $invoice->currency_code = 'IDR';
+        $invoice->user = (object) ['name' => 'John Doe', 'email' => 'john@example.com'];
+
+        $gateway = new Duitku([
+            'merchant_code' => 'M123',
+            'api_key' => 'secret',
+            'payment_method' => 'QRIS',
+            'sandbox_mode' => true,
+        ]);
+
+        $message = $gateway->pay($invoice, 10);
+
+        Log::shouldHaveReceived('error')->once();
+        $this->assertSame('Payment could not be processed. Please try again later.', $message);
+    }
+}

--- a/tests/Unit/DuitkuGatewayTest.php
+++ b/tests/Unit/DuitkuGatewayTest.php
@@ -58,4 +58,22 @@ class DuitkuGatewayTest extends TestCase
         Log::shouldHaveReceived('error')->once();
         $this->assertSame('Payment could not be processed. Please try again later.', $message);
     }
+
+    public function test_can_use_gateway_requires_config()
+    {
+        $gateway = new Duitku([
+            'merchant_code' => '',
+            'api_key' => '',
+            'payment_method' => 'QRIS',
+        ]);
+        $this->assertFalse($gateway->canUseGateway([], 'invoice'));
+
+        $configured = new Duitku([
+            'merchant_code' => 'M123',
+            'api_key' => 'secret',
+            'payment_method' => 'QRIS',
+        ]);
+
+        $this->assertTrue($configured->canUseGateway([], 'invoice'));
+    }
 }


### PR DESCRIPTION
## Summary
- add configurable Duitku gateway with API keys, sandbox toggle, and payment method selection
- send requests to proper API endpoint with signature and error handling
- cover happy and error paths with unit tests

## Testing
- `./vendor/bin/phpunit tests/Unit/DuitkuGatewayTest.php`
- `./vendor/bin/pint`


------
https://chatgpt.com/codex/tasks/task_e_68a42a26d144832ebd619822f5104deb